### PR TITLE
Create gallery of images inside patch editor widget

### DIFF
--- a/coralnet_toolbox/QtMainWindow.py
+++ b/coralnet_toolbox/QtMainWindow.py
@@ -351,7 +351,7 @@ class MainWindow(QMainWindow):
         # Patch Editor menu
         self.patch_edit_action = QAction("Patch Editor", self)
         self.patch_edit_action.triggered.connect(self.open_patch_edit_window_dialog)
-        self.menu_bar.addAction(self.patch_edit_action)        
+        self.menu_bar.addAction(self.patch_edit_action)    
 
         # Ultralytics menu
         self.ml_menu = self.menu_bar.addMenu("Ultralytics")

--- a/coralnet_toolbox/QtPatchEditorWindow.py
+++ b/coralnet_toolbox/QtPatchEditorWindow.py
@@ -2,30 +2,62 @@ import warnings
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-import random
+from PyQt5.QtWidgets import (QGridLayout, QLabel, QDialog, QPushButton)
+from PyQt5.QtGui import QPixmap
+from PyQt5.QtWidgets import QFileDialog
 
-from PyQt5.QtCore import Qt, pyqtSignal, QPointF
-from PyQt5.QtGui import QColor, QPen, QBrush
-from PyQt5.QtWidgets import (QApplication, QGraphicsView, QGraphicsScene, QCheckBox,
-                             QVBoxLayout, QLabel, QDialog, QHBoxLayout, QPushButton,
-                             QComboBox, QSpinBox, QGraphicsPixmapItem, QGraphicsRectItem,
-                             QFormLayout, QButtonGroup)
-
+from coralnet_toolbox.QtImageWindow import ImageWindow
+from coralnet_toolbox.Icons import get_icon
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Classes
 # ----------------------------------------------------------------------------------------------------------------------
 
 class PatchEditorWindowDialog(QDialog):
-    annotationsSampled = pyqtSignal(list, bool)  # Signal to emit the sampled annotations and apply to all flag
-
+    
     def __init__(self, main_window, parent=None):
         super().__init__(parent)
-        self.annotation_window = main_window.annotation_window
-        self.label_window = main_window.label_window
-        self.image_window = main_window.image_window
-
+        
         self.setWindowTitle("Patch Editor")
-        self.setWindowState(Qt.WindowMaximized)  # Ensure the dialog is maximized
+        self.setWindowIcon(get_icon("coral.png"))
+        # self.setWindowState(Qt.WindowMaximized)  # Ensure the dialog is maximized
 
-        self.layout = QVBoxLayout(self)
+        self.layout = QGridLayout()
+        self.setLayout(self.layout)
+
+        self.loadButton = QPushButton("Load Images")
+        self.loadButton.clicked.connect(self.load_images)
+        self.layout.addWidget(self.loadButton, 0, 0)
+
+    def load_images(self):
+        directory = QFileDialog.getExistingDirectory(self, "Select Directory")
+
+        if directory:
+            import os
+
+            self._base_dir = os.getcwd()
+            self._images_dir = os.path.join(self._base_dir, directory)
+
+            self.list_of_images = os.listdir(directory)
+            self.list_of_images = sorted(self.list_of_images)
+
+            print("list images: " + str(self.list_of_images))
+
+            # Length of Images
+            print('Number of Images in the selected folder: {}'.format(len(self.list_of_images)))
+
+        # Create and add image labels to the grid
+        row, col = 0, 0
+        for image in self.list_of_images:
+            image_path = '{}\\{}'.format(self._images_dir, image)
+            label = QLabel()
+            pixmap = QPixmap(image_path)
+            label.setPixmap(pixmap)
+            label.setScaledContents(True)
+            label.setMaximumSize(600, 400) # limit image size
+            self.layout.addWidget(label, row, col)
+
+            col += 1
+            if col > 2:  # 3 columns per row
+                col = 0
+                row += 1


### PR DESCRIPTION
- Add ability to select a folder from OS directory
- Loads images from selected directory into a gallery form (need to add extension check for only image related file extensions)
- Only tested with ~10 images so far

![image](https://github.com/user-attachments/assets/b29426d4-2f44-4669-81d9-1da706db2ff8)

![image](https://github.com/user-attachments/assets/07219cf5-1010-432b-8da9-5e8f33ad5c57)

![image](https://github.com/user-attachments/assets/68336cd7-cac9-474f-af9d-0a22332de10a)
